### PR TITLE
adding snyk simple scan

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,18 @@
+name: Node using Snyk
+on: push
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/node@master
+        continue-on-error: true # To make sure that SARIF upload gets called
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --sarif-file-output=snyk.sarif
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: snyk.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Node
+node_modules/
+.env
+npm-debug.log
+yarn-debug.log
+yarn-error.log
+
+# Logs
+logs
+*.log
+
+# OS
+.DS_Store
+Thumbs.db
+
+# VSCode
+.vscode/
+
+# Misc
+*.swp
+*.swo
+
+# Coverage
+coverage/
+
+# Build
+build/
+dist/
+
+# Copilot instructions
+.github/copilot-instructions.md


### PR DESCRIPTION
Security scanning integration:

* [`.github/workflows/snyk.yml`](diffhunk://#diff-279a5a5997dd6e7a67267df6229cd45adb7acdb39c8ebab573f98e524deb0fd5R1-R18): Added a new workflow named "Node using Snyk" that runs on `push` events. It uses the Snyk action to scan for vulnerabilities and uploads the results as a SARIF file to GitHub Code Scanning.